### PR TITLE
performance, deprecations and a failed test

### DIFF
--- a/src/main/java/org/scale7/cassandra/pelops/Bytes.java
+++ b/src/main/java/org/scale7/cassandra/pelops/Bytes.java
@@ -19,25 +19,6 @@ public class Bytes {
     public static final Bytes EMPTY = fromByteArray(new byte[0]);
     public static final Bytes NULL = fromByteBuffer(null);
 
-    static final int SIZEOF_BYTE = Byte.SIZE / Byte.SIZE;
-
-    static final int SIZEOF_BOOLEAN = SIZEOF_BYTE;
-
-    static final byte BOOLEAN_TRUE = (byte) 1;
-    static final byte BOOLEAN_FALSE = (byte) 0;
-    static final int SIZEOF_CHAR = Character.SIZE / Byte.SIZE;
-
-    static final int SIZEOF_SHORT = Short.SIZE / Byte.SIZE;
-
-    static final int SIZEOF_INT = Integer.SIZE / Byte.SIZE;
-    static final int SIZEOF_LONG = Long.SIZE / Byte.SIZE;
-    static final int SIZEOF_FLOAT = Float.SIZE / Byte.SIZE;
-
-    static final int SIZEOF_DOUBLE = Double.SIZE / Byte.SIZE;
-    static final int SIZEOF_UUID = SIZEOF_LONG + SIZEOF_LONG;
-
-    static final Charset UTF8 = Charset.forName("UTF-8");
-
     private final ByteBuffer bytes;
     private int hashCode = -1;
 
@@ -172,7 +153,7 @@ public class Bytes {
      * @return the Bytes instance
      */
     public static Bytes fromByteArray(byte[] value) {
-        return new Bytes(ByteBuffer.wrap(value), false);
+        return new Bytes(BufferHelper.fromByteArray(value), false);
     }
 
     /**
@@ -193,7 +174,7 @@ public class Bytes {
      * @see java.nio.ByteBuffer for details on serializaion format
      */
     public static Bytes fromChar(char value) {
-        return new Bytes(ByteBuffer.allocate(SIZEOF_CHAR).putChar(value), false);
+        return new Bytes(BufferHelper.fromChar(value), false);
     }
 
     /**
@@ -215,7 +196,7 @@ public class Bytes {
      * @see java.nio.ByteBuffer for details on serializaion format
      */
     public static Bytes fromByte(byte value) {
-        return new Bytes(ByteBuffer.allocate(SIZEOF_BYTE).put(value), false);
+        return new Bytes(BufferHelper.fromByte(value), false);
     }
 
     /**
@@ -237,7 +218,7 @@ public class Bytes {
      * @see java.nio.ByteBuffer for details on serializaion format
      */
     public static Bytes fromLong(long value) {
-        return new Bytes(ByteBuffer.allocate(SIZEOF_LONG).putLong(value), false);
+        return new Bytes(BufferHelper.fromLong(value), false);
     }
 
     /**
@@ -259,7 +240,7 @@ public class Bytes {
      * @see java.nio.ByteBuffer for details on serializaion format
      */
     public static Bytes fromInt(int value) {
-        return new Bytes(ByteBuffer.allocate(SIZEOF_INT).putInt(value), false);
+        return new Bytes(BufferHelper.fromInt(value), false);
     }
 
     /**
@@ -281,7 +262,7 @@ public class Bytes {
      * @see java.nio.ByteBuffer for details on serializaion format
      */
     public static Bytes fromShort(short value) {
-        return new Bytes(ByteBuffer.allocate(SIZEOF_SHORT).putShort(value), false);
+        return new Bytes(BufferHelper.fromShort(value), false);
     }
 
     /**
@@ -303,7 +284,7 @@ public class Bytes {
      * @see java.nio.ByteBuffer for details on serializaion format
      */
     public static Bytes fromDouble(double value) {
-        return new Bytes(ByteBuffer.allocate(SIZEOF_DOUBLE).putDouble(value), false);
+        return new Bytes(BufferHelper.fromDouble(value), false);
     }
 
     /**
@@ -325,7 +306,7 @@ public class Bytes {
      * @see java.nio.ByteBuffer for details on serializaion format
      */
     public static Bytes fromFloat(float value) {
-        return new Bytes(ByteBuffer.allocate(SIZEOF_FLOAT).putFloat(value), false);
+        return new Bytes(BufferHelper.fromFloat(value), false);
     }
 
     /**
@@ -347,7 +328,7 @@ public class Bytes {
      * @see java.nio.ByteBuffer for details on serializaion format
      */
     public static Bytes fromBoolean(boolean value) {
-        return new Bytes(ByteBuffer.allocate(SIZEOF_BOOLEAN).put(value ? BOOLEAN_TRUE : BOOLEAN_FALSE), false);
+        return new Bytes(BufferHelper.fromBoolean(value), false);
     }
 
     /**
@@ -370,7 +351,7 @@ public class Bytes {
      * @see java.nio.ByteBuffer for details on long serializaion format
      */
     public static Bytes fromUuid(UUID value) {
-        return value == null ? NULL : fromUuid(value.getMostSignificantBits(), value.getLeastSignificantBits());
+        return value == null ? NULL : new Bytes(BufferHelper.fromUuid(value), false);
     }
 
     /**
@@ -383,7 +364,7 @@ public class Bytes {
      * @see java.nio.ByteBuffer for details on long serializaion format
      */
     public static Bytes fromUuid(String value) {
-        return value == null ? NULL : fromUuid(UUID.fromString(value));
+        return value == null ? NULL : new Bytes(BufferHelper.fromUuid(value), false);
     }
 
     /**
@@ -396,7 +377,7 @@ public class Bytes {
      * @see java.nio.ByteBuffer for details on long serializaion format
      */
     public static Bytes fromUuid(long msb, long lsb) {
-        return new Bytes(ByteBuffer.allocate(SIZEOF_UUID).putLong(msb).putLong(lsb), false);
+        return new Bytes(BufferHelper.fromUuid(msb, lsb), false);
     }
 
     /**
@@ -459,7 +440,7 @@ public class Bytes {
      * @see String#getBytes(java.nio.charset.Charset) for details on the format
      */
     public static Bytes fromUTF8(String value) {
-        return value == null ? NULL : fromByteArray(value.getBytes(UTF8));
+        return value == null ? NULL : new Bytes(BufferHelper.fromUTF8(value), false);
     }
 
 
@@ -725,7 +706,7 @@ public class Bytes {
     public boolean toBoolean() throws IllegalStateException {
         try {
             bytes.reset();
-            return this.bytes.get() != BOOLEAN_FALSE;
+            return this.bytes.get() != BufferHelper.BOOLEAN_FALSE;
         } catch (BufferUnderflowException e) {
             throw new IllegalStateException("Failed to read value due to invalid format.  See cause for details...", e);
         } finally {
@@ -829,7 +810,7 @@ public class Bytes {
 
         try {
             bytes.reset();
-            return new String(this.bytes.array(), this.bytes.position(), this.bytes.remaining(), UTF8);
+            return new String(this.bytes.array(), this.bytes.position(), this.bytes.remaining(), BufferHelper.UTF8);
         } finally {
             this.bytes.reset();
         }
@@ -847,7 +828,7 @@ public class Bytes {
             return null;
         int position = bytes.position();
         try {
-            return new String(bytes.array(), position, bytes.remaining(), UTF8);
+            return new String(bytes.array(), position, bytes.remaining(), BufferHelper.UTF8);
         } finally {
             bytes.position(position);
         }
@@ -862,7 +843,7 @@ public class Bytes {
     public static String toUTF8(byte[] bytes) {
         if (bytes == null)
             return null;
-        return new String(bytes, UTF8);
+        return new String(bytes, BufferHelper.UTF8);
     }
 
     /**
@@ -982,7 +963,7 @@ public class Bytes {
 
         public CompositeBuilder addByteBuffer(ByteBuffer value) {
             parts.add(value);
-            length += value.remaining();
+            length += value.rewind().remaining();
             return this;
         }
 
@@ -991,91 +972,91 @@ public class Bytes {
         }
 
         public CompositeBuilder addBoolean(boolean value) {
-            return addBytes(Bytes.fromBoolean(value));
+            return addByteBuffer(BufferHelper.fromBoolean(value));
         }
 
         public CompositeBuilder addBoolean(Boolean value) {
-            return addBytes(Bytes.fromBoolean(value));
+            return addByteBuffer(BufferHelper.fromBoolean(value));
         }
 
         public CompositeBuilder addByte(byte value) {
-            return addBytes(Bytes.fromByte(value));
+            return addByteBuffer(BufferHelper.fromByte(value));
         }
 
         public CompositeBuilder addByte(Byte value) {
-            return addBytes(Bytes.fromByte(value));
+            return addByteBuffer(BufferHelper.fromByte(value));
         }
 
         public CompositeBuilder addByteArray(byte[] value) {
-            return addBytes(Bytes.fromByteArray(value));
+            return addByteBuffer(BufferHelper.fromByteArray(value));
         }
 
         public CompositeBuilder addChar(char value) {
-            return addBytes(Bytes.fromChar(value));
+            return addByteBuffer(BufferHelper.fromChar(value));
         }
 
         public CompositeBuilder addChar(Character value) {
-            return addBytes(Bytes.fromChar(value));
+            return addByteBuffer(BufferHelper.fromChar(value));
         }
 
         public CompositeBuilder addDouble(double value) {
-            return addBytes(Bytes.fromDouble(value));
+            return addByteBuffer(BufferHelper.fromDouble(value));
         }
 
         public CompositeBuilder addDouble(Double value) {
-            return addBytes(Bytes.fromDouble(value));
+            return addByteBuffer(BufferHelper.fromDouble(value));
         }
 
         public CompositeBuilder addFloat(float value) {
-            return addBytes(Bytes.fromFloat(value));
+            return addByteBuffer(BufferHelper.fromFloat(value));
         }
 
         public CompositeBuilder addFloat(Float value) {
-            return addBytes(Bytes.fromFloat(value));
+            return addByteBuffer(BufferHelper.fromFloat(value));
         }
 
         public CompositeBuilder addInt(int value) {
-            return addBytes(Bytes.fromInt(value));
+            return addByteBuffer(BufferHelper.fromInt(value));
         }
 
         public CompositeBuilder addInt(Integer value) {
-            return addBytes(Bytes.fromInt(value));
+            return addByteBuffer(BufferHelper.fromInt(value));
         }
 
         public CompositeBuilder addLong(long value) {
-            return addBytes(Bytes.fromLong(value));
+            return addByteBuffer(BufferHelper.fromLong(value));
         }
 
         public CompositeBuilder addLong(Long value) {
-            return addBytes(Bytes.fromLong(value));
+            return addByteBuffer(BufferHelper.fromLong(value));
         }
 
         public CompositeBuilder addShort(short value) {
-            return addBytes(Bytes.fromShort(value));
+            return addByteBuffer(BufferHelper.fromShort(value));
         }
 
         public CompositeBuilder addShort(Short value) {
-            return addBytes(Bytes.fromShort(value));
+            return addByteBuffer(BufferHelper.fromShort(value));
         }
 
         public CompositeBuilder addUTF8(String str) {
-            return addBytes(Bytes.fromUTF8(str));
+            return addByteBuffer(BufferHelper.fromUTF8(str));
         }
 
         public CompositeBuilder addUuid(UUID value) {
-            return addBytes(Bytes.fromUuid(value));
+            return addByteBuffer(BufferHelper.fromUuid(value));
         }
 
         public CompositeBuilder addUuid(String value) {
-            return addBytes(Bytes.fromUuid(value));
+            return addByteBuffer(BufferHelper.fromUuid(value));
         }
 
         public CompositeBuilder addUuid(long msb, long lsb) {
-            return addBytes(Bytes.fromUuid(msb, lsb));
+            return addByteBuffer(BufferHelper.fromUuid(msb, lsb));
         }
 
         public CompositeBuilder addTimeUuid(com.eaio.uuid.UUID value) {
-            return addBytes(Bytes.fromTimeUuid(value));
+            return addByteBuffer(BufferHelper.fromUuid(value.getTime(), value.getClockSeqAndNode()));
         }
 
         /** @deprecated use {@link #addUuid(UUID)} instead */
@@ -1103,6 +1084,78 @@ public class Bytes {
             }
 
             return new Bytes(buffer, false);
+        }
+    }
+
+    /**
+     * Encapsulates ByteBuffer allocation.
+     */
+    static class BufferHelper {
+
+        static final int SIZEOF_BYTE = Byte.SIZE / Byte.SIZE;
+        static final int SIZEOF_BOOLEAN = SIZEOF_BYTE;
+        static final byte BOOLEAN_TRUE = (byte)1;
+        static final byte BOOLEAN_FALSE = (byte)0;
+        static final int SIZEOF_CHAR = Character.SIZE / Byte.SIZE;
+        static final int SIZEOF_SHORT = Short.SIZE / Byte.SIZE;
+        static final int SIZEOF_INT = Integer.SIZE / Byte.SIZE;
+        static final int SIZEOF_LONG = Long.SIZE / Byte.SIZE;
+        static final int SIZEOF_FLOAT = Float.SIZE / Byte.SIZE;
+        static final int SIZEOF_DOUBLE = Double.SIZE / Byte.SIZE;
+        static final int SIZEOF_UUID = SIZEOF_LONG + SIZEOF_LONG;
+
+        public static final Charset UTF8 = Charset.forName("UTF-8");
+
+        public static ByteBuffer fromByteArray(byte[] value) {
+            return ByteBuffer.wrap(value);
+        }
+
+        public static ByteBuffer fromChar(char value) {
+            return ByteBuffer.allocate(SIZEOF_CHAR).putChar(value);
+        }
+
+        public static ByteBuffer fromByte(byte value) {
+            return ByteBuffer.allocate(SIZEOF_BYTE).put(value);
+        }
+
+        public static ByteBuffer fromLong(long value) {
+            return ByteBuffer.allocate(SIZEOF_LONG).putLong(value);
+        }
+
+        public static ByteBuffer fromInt(int value) {
+            return ByteBuffer.allocate(SIZEOF_INT).putInt(value);
+        }
+
+        public static ByteBuffer fromShort(short value) {
+            return ByteBuffer.allocate(SIZEOF_SHORT).putShort(value);
+        }
+
+        public static ByteBuffer fromDouble(double value) {
+            return ByteBuffer.allocate(SIZEOF_DOUBLE).putDouble(value);
+        }
+
+        public static ByteBuffer fromFloat(float value) {
+            return ByteBuffer.allocate(SIZEOF_FLOAT).putFloat(value);
+        }
+
+        public static ByteBuffer fromBoolean(boolean value) {
+            return ByteBuffer.allocate(SIZEOF_BOOLEAN).put(value ? BOOLEAN_TRUE : BOOLEAN_FALSE);
+        }
+
+        public static ByteBuffer fromUuid(UUID value) {
+            return fromUuid(value.getMostSignificantBits(), value.getLeastSignificantBits());
+        }
+
+        public static ByteBuffer fromUuid(String value) {
+            return fromUuid(UUID.fromString(value));
+        }
+
+        public static ByteBuffer fromUuid(long msb, long lsb) {
+            return ByteBuffer.allocate(SIZEOF_UUID).putLong(msb).putLong(lsb);
+        }
+
+        public static ByteBuffer fromUTF8(String value) {
+            return fromByteArray(value.getBytes(UTF8));
         }
     }
 }

--- a/src/main/java/org/scale7/cassandra/pelops/Bytes.java
+++ b/src/main/java/org/scale7/cassandra/pelops/Bytes.java
@@ -413,7 +413,9 @@ public class Bytes {
      * @param value the value
      * @return the instance or null if the value provided was null
      * @see java.nio.ByteBuffer for details on long serializaion format
+     * @deprecated use {@link #fromUuid(UUID)} instead
      */
+    @Deprecated
     public static Bytes fromTimeUuid(UUID value) {
         return fromUuid(value);
     }
@@ -424,7 +426,9 @@ public class Bytes {
      * @param value the value
      * @return the instance or null if the value provided was null
      * @see java.nio.ByteBuffer for details on long serializaion format
+     * @deprecated use {@link #fromUuid(String)} instead
      */
+    @Deprecated
     public static Bytes fromTimeUuid(String value) {
         return fromUuid(value);
     }
@@ -436,7 +440,9 @@ public class Bytes {
      * @param clockSeqAndNode the clockSeqAndNode value
      * @return the instance or null if the value provided was null
      * @see java.nio.ByteBuffer for details on long serializaion format
+     * @deprecated use {@link #fromUuid(long, long)} instead
      */
+    @Deprecated
     public static Bytes fromTimeUuid(long time, long clockSeqAndNode) {
         return fromUuid(time, clockSeqAndNode);
     }
@@ -779,7 +785,9 @@ public class Bytes {
      *
      * @param uuid The bytes representing the uuid.
      * @return A uuid object
+     * @deprecated use {@link #uuidFromBytes(byte[])} instead
      */
+    @Deprecated
     public static UUID timeUuidFromBytes(byte[] uuid) {
         return uuidFromBytes(uuid);
     }
@@ -797,7 +805,9 @@ public class Bytes {
      * Createa a UTF-8 representation of a uuid from a bytes array
      * @param uuid The bytes representing the uuid.
      * @return A string representation of the uuid
+     * @deprecated use {@link #utf8UuidFromBytes(byte[])} instead
      */
+    @Deprecated
     public static String utf8TimeUuidFromBytes(byte[] uuid) {
     	return utf8UuidFromBytes(uuid);
     }
@@ -1064,14 +1074,20 @@ public class Bytes {
             return addBytes(Bytes.fromTimeUuid(value));
         }
 
+        /** @deprecated use {@link #addUuid(UUID)} instead */
+        @Deprecated
         public CompositeBuilder addTimeUuid(UUID value) {
             return addUuid(value);
         }
 
+        /** @deprecated use {@link #addUuid(String)} instead */
+        @Deprecated
         public CompositeBuilder addTimeUuid(String value) {
             return addUuid(value);
         }
 
+        /** @deprecated use {@link #addUuid(long, long)} instead */
+        @Deprecated
         public CompositeBuilder addTimeUuid(long time, long clockSeqAndNode) {
             return addUuid(time, clockSeqAndNode);
         }

--- a/src/main/java/org/scale7/cassandra/pelops/RowDeletor.java
+++ b/src/main/java/org/scale7/cassandra/pelops/RowDeletor.java
@@ -39,12 +39,11 @@ public class RowDeletor extends Operand {
 	 * @param cLevel					The Cassandra consistency level to be used
 	 * @throws PelopsException
 	 */
-	public void deleteRow(final String columnFamily, final Bytes rowKey, final ConsistencyLevel cLevel) throws PelopsException {
+	public void deleteRow(String columnFamily, final Bytes rowKey, final ConsistencyLevel cLevel) throws PelopsException {
+        final ColumnPath path = new ColumnPath(columnFamily);
 		IOperation<Void> operation = new IOperation<Void>() {
 			@Override
 			public Void execute(IPooledConnection conn) throws Exception {
-
-				ColumnPath path = new ColumnPath(columnFamily);
 				conn.getAPI().remove(nullSafeGet(rowKey), path, timestamp, cLevel);
 				return null;
 			}

--- a/src/main/java/org/scale7/cassandra/pelops/Selector.java
+++ b/src/main/java/org/scale7/cassandra/pelops/Selector.java
@@ -293,10 +293,10 @@ public class Selector extends Operand {
      * @throws PelopsException if an error occurs
      */
     public Column getColumnFromRow(final String columnFamily, final Bytes rowKey, final Bytes colName, final ConsistencyLevel cLevel) throws NotFoundException, PelopsException {
+        final ColumnPath cp = newColumnPath(columnFamily, null, colName);
         IOperation<Column> operation = new IOperation<Column>() {
             @Override
             public Column execute(IThriftPool.IPooledConnection conn) throws Exception {
-                ColumnPath cp = newColumnPath(columnFamily, null, colName);
                 ColumnOrSuperColumn cosc = conn.getAPI().get(nullSafeGet(rowKey), cp, cLevel);
                 return cosc.column;
             }
@@ -343,10 +343,10 @@ public class Selector extends Operand {
      * @throws PelopsException if an error occurs
      */
     public SuperColumn getSuperColumnFromRow(final String columnFamily, final Bytes rowKey, final Bytes superColName, final ConsistencyLevel cLevel) throws NotFoundException, PelopsException {
+        final ColumnPath cp = newColumnPath(columnFamily, superColName, null);
         IOperation<SuperColumn> operation = new IOperation<SuperColumn>() {
             @Override
             public SuperColumn execute(IThriftPool.IPooledConnection conn) throws Exception {
-                ColumnPath cp = newColumnPath(columnFamily, superColName, null);
                 ColumnOrSuperColumn cosc = conn.getAPI().get(nullSafeGet(rowKey), cp, cLevel);
                 return cosc.super_column;
             }
@@ -426,10 +426,10 @@ public class Selector extends Operand {
      * @throws PelopsException if an error occurs
      */
     public Column getSubColumnFromRow(final String columnFamily, final Bytes rowKey, final Bytes superColName, final Bytes subColName, final ConsistencyLevel cLevel) throws NotFoundException, PelopsException {
+        final ColumnPath cp = newColumnPath(columnFamily, superColName, subColName);
         IOperation<Column> operation = new IOperation<Column>() {
             @Override
             public Column execute(IThriftPool.IPooledConnection conn) throws Exception {
-                ColumnPath cp = newColumnPath(columnFamily, superColName, subColName);
                 ColumnOrSuperColumn cosc = conn.getAPI().get(nullSafeGet(rowKey), cp, cLevel);
                 return cosc.column;
             }
@@ -637,10 +637,11 @@ public class Selector extends Operand {
      * @throws PelopsException if an error occurs
      */
     public List<SuperColumn> getSuperColumnsFromRow(final String columnFamily, final Bytes rowKey, final SlicePredicate colPredicate, final ConsistencyLevel cLevel) throws PelopsException {
+        final ColumnParent cp = newColumnParent(columnFamily);
         IOperation<List<SuperColumn>> operation = new IOperation<List<SuperColumn>>() {
             @Override
             public List<SuperColumn> execute(IPooledConnection conn) throws Exception {
-                List<ColumnOrSuperColumn> apiResult = conn.getAPI().get_slice(nullSafeGet(rowKey), newColumnParent(columnFamily), colPredicate, cLevel);
+                List<ColumnOrSuperColumn> apiResult = conn.getAPI().get_slice(nullSafeGet(rowKey), cp, colPredicate, cLevel);
                 return toSuperColumnList(apiResult);
             }
         };
@@ -1094,10 +1095,11 @@ public class Selector extends Operand {
      * @throws PelopsException if an error occurs
      */
     public Map<Bytes, List<SuperColumn>> getSuperColumnsFromRows(final String columnFamily, final List<Bytes> rowKeys, final SlicePredicate colPredicate, final ConsistencyLevel cLevel) throws PelopsException {
+        final ColumnParent cp = newColumnParent(columnFamily);
         IOperation<Map<Bytes, List<SuperColumn>>> operation = new IOperation<Map<Bytes, List<SuperColumn>>>() {
             @Override
             public Map<Bytes, List<SuperColumn>> execute(IPooledConnection conn) throws Exception {
-                Map<ByteBuffer, List<ColumnOrSuperColumn>> apiResult = conn.getAPI().multiget_slice(Bytes.transformBytesToList(rowKeys), newColumnParent(columnFamily), colPredicate, cLevel);
+                Map<ByteBuffer, List<ColumnOrSuperColumn>> apiResult = conn.getAPI().multiget_slice(Bytes.transformBytesToList(rowKeys), cp, colPredicate, cLevel);
                 Map<Bytes, List<SuperColumn>> result = new LinkedHashMap<Bytes, List<SuperColumn>>();
                 for (Bytes rowKey : rowKeys) {
                     List<ColumnOrSuperColumn> coscList = apiResult.get(rowKey.getBytes());
@@ -1137,10 +1139,11 @@ public class Selector extends Operand {
      * @throws PelopsException if an error occurs
      */
     public Map<String, List<SuperColumn>> getSuperColumnsFromRowsUtf8Keys(final String columnFamily, final List<String> rowKeys, final SlicePredicate colPredicate, final ConsistencyLevel cLevel) throws PelopsException {
+        final ColumnParent cp = newColumnParent(columnFamily);
         IOperation<Map<String, List<SuperColumn>>> operation = new IOperation<Map<String, List<SuperColumn>>>() {
             @Override
             public Map<String, List<SuperColumn>> execute(IPooledConnection conn) throws Exception {
-                Map<ByteBuffer, List<ColumnOrSuperColumn>> apiResult = conn.getAPI().multiget_slice(Bytes.transformUTF8ToList(rowKeys), newColumnParent(columnFamily), colPredicate, cLevel);
+                Map<ByteBuffer, List<ColumnOrSuperColumn>> apiResult = conn.getAPI().multiget_slice(Bytes.transformUTF8ToList(rowKeys), cp, colPredicate, cLevel);
                 Map<String, List<SuperColumn>> result = new LinkedHashMap<String, List<SuperColumn>>();
                 for (Map.Entry<ByteBuffer, List<ColumnOrSuperColumn>> rowEntry : apiResult.entrySet()) {
                     List<SuperColumn> columns = toSuperColumnList(rowEntry.getValue());
@@ -1421,10 +1424,11 @@ public class Selector extends Operand {
      * @throws PelopsException if an error occurs
      */
     public Map<Bytes, List<SuperColumn>> getSuperColumnsFromRows(final String columnFamily, final KeyRange keyRange, final SlicePredicate colPredicate, final ConsistencyLevel cLevel) throws PelopsException {
+        final ColumnParent cp = newColumnParent(columnFamily);
         IOperation<Map<Bytes, List<SuperColumn>>> operation = new IOperation<Map<Bytes, List<SuperColumn>>>() {
             @Override
             public Map<Bytes, List<SuperColumn>> execute(IPooledConnection conn) throws Exception {
-                List<KeySlice> apiResult = conn.getAPI().get_range_slices(newColumnParent(columnFamily), colPredicate, keyRange, cLevel);
+                List<KeySlice> apiResult = conn.getAPI().get_range_slices(cp, colPredicate, keyRange, cLevel);
                 Map<Bytes, List<SuperColumn>> result = new LinkedHashMap<Bytes, List<SuperColumn>>();
                 for (KeySlice ks : apiResult) {
                     List<ColumnOrSuperColumn> coscList = ks.columns;
@@ -1466,10 +1470,11 @@ public class Selector extends Operand {
      * @throws PelopsException if an error occurs
      */
     public Map<String, List<SuperColumn>> getSuperColumnsFromRowsUtf8Keys(final String columnFamily, final KeyRange keyRange, final SlicePredicate colPredicate, final ConsistencyLevel cLevel) throws PelopsException {
+        final ColumnParent cp = newColumnParent(columnFamily);
         IOperation<Map<String, List<SuperColumn>>> operation = new IOperation<Map<String, List<SuperColumn>>>() {
             @Override
             public Map<String, List<SuperColumn>> execute(IThriftPool.IPooledConnection conn) throws Exception {
-                List<KeySlice> apiResult = conn.getAPI().get_range_slices(newColumnParent(columnFamily), colPredicate, keyRange, cLevel);
+                List<KeySlice> apiResult = conn.getAPI().get_range_slices(cp, colPredicate, keyRange, cLevel);
                 Map<String, List<SuperColumn>> result = new LinkedHashMap<String, List<SuperColumn>>();
                 for (KeySlice ks : apiResult) {
                     List<ColumnOrSuperColumn> coscList = ks.columns;

--- a/src/main/java/org/scale7/cassandra/pelops/Selector.java
+++ b/src/main/java/org/scale7/cassandra/pelops/Selector.java
@@ -1145,7 +1145,7 @@ public class Selector extends Operand {
             @Override
             public Map<String, List<SuperColumn>> execute(IPooledConnection conn) throws Exception {
                 Map<ByteBuffer, List<ColumnOrSuperColumn>> apiResult = conn.getAPI().multiget_slice(Bytes.transformUTF8ToList(rowKeys), newColumnParent(columnFamily), colPredicate, cLevel);
-                Map<String, List<SuperColumn>> result = new HashMap<String, List<SuperColumn>>();
+                Map<String, List<SuperColumn>> result = new LinkedHashMap<String, List<SuperColumn>>();
                 for (ByteBuffer rowKey : apiResult.keySet()) {
                     List<ColumnOrSuperColumn> coscList = apiResult.get(rowKey);
                     List<SuperColumn> columns = toSuperColumnList(coscList);

--- a/src/main/java/org/scale7/cassandra/pelops/Selector.java
+++ b/src/main/java/org/scale7/cassandra/pelops/Selector.java
@@ -264,7 +264,7 @@ public class Selector extends Operand {
      * @throws NotFoundException            If no value is present
      * @throws PelopsException if an error occurs
      */
-    public Column getColumnFromRow(final String columnFamily, final String rowKey, final String colName, final ConsistencyLevel cLevel) throws NotFoundException, PelopsException {
+    public Column getColumnFromRow(String columnFamily, String rowKey, String colName, ConsistencyLevel cLevel) throws NotFoundException, PelopsException {
         return getColumnFromRow(columnFamily, rowKey, fromUTF8(colName), cLevel);
     }
 
@@ -278,7 +278,7 @@ public class Selector extends Operand {
      * @throws NotFoundException            If no value is present
      * @throws PelopsException if an error occurs
      */
-    public Column getColumnFromRow(final String columnFamily, final String rowKey, final Bytes colName, final ConsistencyLevel cLevel) throws NotFoundException, PelopsException {
+    public Column getColumnFromRow(String columnFamily, String rowKey, Bytes colName, ConsistencyLevel cLevel) throws NotFoundException, PelopsException {
         return getColumnFromRow(columnFamily, fromUTF8(rowKey), colName, cLevel);
     }
 
@@ -292,7 +292,7 @@ public class Selector extends Operand {
      * @throws NotFoundException            If no value is present
      * @throws PelopsException if an error occurs
      */
-    public Column getColumnFromRow(final String columnFamily, final Bytes rowKey, final Bytes colName, final ConsistencyLevel cLevel) throws NotFoundException, PelopsException {
+    public Column getColumnFromRow(String columnFamily, final Bytes rowKey, Bytes colName, final ConsistencyLevel cLevel) throws NotFoundException, PelopsException {
         final ColumnPath cp = newColumnPath(columnFamily, null, colName);
         IOperation<Column> operation = new IOperation<Column>() {
             @Override
@@ -314,7 +314,7 @@ public class Selector extends Operand {
      * @throws NotFoundException            If no value is present
      * @throws PelopsException if an error occurs
      */
-    public SuperColumn getSuperColumnFromRow(final String columnFamily, final String rowKey, final String superColName, final ConsistencyLevel cLevel) throws NotFoundException, PelopsException {
+    public SuperColumn getSuperColumnFromRow(String columnFamily, String rowKey, String superColName, ConsistencyLevel cLevel) throws NotFoundException, PelopsException {
         return getSuperColumnFromRow(columnFamily, rowKey, fromUTF8(superColName), cLevel);
     }
 
@@ -328,7 +328,7 @@ public class Selector extends Operand {
      * @throws NotFoundException            If no value is present
      * @throws PelopsException if an error occurs
      */
-    public SuperColumn getSuperColumnFromRow(final String columnFamily, final String rowKey, final Bytes superColName, final ConsistencyLevel cLevel) throws NotFoundException, PelopsException {
+    public SuperColumn getSuperColumnFromRow(String columnFamily, String rowKey, Bytes superColName, ConsistencyLevel cLevel) throws NotFoundException, PelopsException {
         return getSuperColumnFromRow(columnFamily, fromUTF8(rowKey), superColName, cLevel);
     }
 
@@ -342,7 +342,7 @@ public class Selector extends Operand {
      * @throws NotFoundException            If no value is present
      * @throws PelopsException if an error occurs
      */
-    public SuperColumn getSuperColumnFromRow(final String columnFamily, final Bytes rowKey, final Bytes superColName, final ConsistencyLevel cLevel) throws NotFoundException, PelopsException {
+    public SuperColumn getSuperColumnFromRow(String columnFamily, final Bytes rowKey, Bytes superColName, final ConsistencyLevel cLevel) throws NotFoundException, PelopsException {
         final ColumnPath cp = newColumnPath(columnFamily, superColName, null);
         IOperation<SuperColumn> operation = new IOperation<SuperColumn>() {
             @Override
@@ -365,7 +365,7 @@ public class Selector extends Operand {
      * @throws NotFoundException            If no value is present
      * @throws PelopsException if an error occurs
      */
-    public Column getSubColumnFromRow(final String columnFamily, final String rowKey, final Bytes superColName, final String subColName, final ConsistencyLevel cLevel) throws NotFoundException, PelopsException {
+    public Column getSubColumnFromRow(String columnFamily, String rowKey, Bytes superColName, String subColName, ConsistencyLevel cLevel) throws NotFoundException, PelopsException {
         return getSubColumnFromRow(columnFamily, fromUTF8(rowKey), superColName, fromUTF8(subColName), cLevel);
     }
 
@@ -380,7 +380,7 @@ public class Selector extends Operand {
      * @throws NotFoundException            If no value is present
      * @throws PelopsException if an error occurs
      */
-    public Column getSubColumnFromRow(final String columnFamily, final String rowKey, final String superColName, final String subColName, final ConsistencyLevel cLevel) throws NotFoundException, PelopsException {
+    public Column getSubColumnFromRow(String columnFamily, String rowKey, String superColName, String subColName, ConsistencyLevel cLevel) throws NotFoundException, PelopsException {
         return getSubColumnFromRow(columnFamily, fromUTF8(rowKey), fromUTF8(superColName), fromUTF8(subColName), cLevel);
     }
 
@@ -395,7 +395,7 @@ public class Selector extends Operand {
      * @throws NotFoundException            If no value is present
      * @throws PelopsException if an error occurs
      */
-    public Column getSubColumnFromRow(final String columnFamily, final String rowKey, final String superColName, final Bytes subColName, final ConsistencyLevel cLevel) throws NotFoundException, PelopsException {
+    public Column getSubColumnFromRow(String columnFamily, String rowKey, String superColName, Bytes subColName, ConsistencyLevel cLevel) throws NotFoundException, PelopsException {
         return getSubColumnFromRow(columnFamily, fromUTF8(rowKey), fromUTF8(superColName), subColName, cLevel);
     }
 
@@ -410,7 +410,7 @@ public class Selector extends Operand {
      * @throws NotFoundException            If no value is present
      * @throws PelopsException if an error occurs
      */
-    public Column getSubColumnFromRow(final String columnFamily, final String rowKey, final Bytes superColName, final Bytes subColName, final ConsistencyLevel cLevel) throws NotFoundException, PelopsException {
+    public Column getSubColumnFromRow(String columnFamily, String rowKey, Bytes superColName, Bytes subColName, ConsistencyLevel cLevel) throws NotFoundException, PelopsException {
         return getSubColumnFromRow(columnFamily, fromUTF8(rowKey), superColName, subColName, cLevel);
     }
 
@@ -425,7 +425,7 @@ public class Selector extends Operand {
      * @throws NotFoundException            If no value is present
      * @throws PelopsException if an error occurs
      */
-    public Column getSubColumnFromRow(final String columnFamily, final Bytes rowKey, final Bytes superColName, final Bytes subColName, final ConsistencyLevel cLevel) throws NotFoundException, PelopsException {
+    public Column getSubColumnFromRow(String columnFamily, final Bytes rowKey, Bytes superColName, Bytes subColName, final ConsistencyLevel cLevel) throws NotFoundException, PelopsException {
         final ColumnPath cp = newColumnPath(columnFamily, superColName, subColName);
         IOperation<Column> operation = new IOperation<Column>() {
             @Override
@@ -573,7 +573,7 @@ public class Selector extends Operand {
         return getColumnsFromRow(newColumnParent(columnFamily, superColName), rowKey, colPredicate, cLevel);
     }
 
-    private List<Column> getColumnsFromRow(final ColumnParent colParent, final String rowKey, final SlicePredicate colPredicate, final ConsistencyLevel cLevel) throws PelopsException {
+    private List<Column> getColumnsFromRow(ColumnParent colParent, String rowKey, SlicePredicate colPredicate, ConsistencyLevel cLevel) throws PelopsException {
         return getColumnsFromRow(colParent, fromUTF8(rowKey), colPredicate, cLevel);
     }
 
@@ -597,7 +597,7 @@ public class Selector extends Operand {
      * @return                              A list of matching columns
      * @throws PelopsException if an error occurs
      */
-    public List<SuperColumn> getSuperColumnsFromRow(final String columnFamily, final String rowKey, final boolean reversed, final ConsistencyLevel cLevel) throws PelopsException {
+    public List<SuperColumn> getSuperColumnsFromRow(String columnFamily, String rowKey, boolean reversed, ConsistencyLevel cLevel) throws PelopsException {
         return getSuperColumnsFromRow(columnFamily, fromUTF8(rowKey), columnsPredicateAll(reversed), cLevel);
     }
 
@@ -610,7 +610,7 @@ public class Selector extends Operand {
      * @return                              A list of matching columns
      * @throws PelopsException if an error occurs
      */
-    public List<SuperColumn> getSuperColumnsFromRow(final String columnFamily, final String rowKey, final SlicePredicate colPredicate, final ConsistencyLevel cLevel) throws PelopsException {
+    public List<SuperColumn> getSuperColumnsFromRow(String columnFamily, String rowKey, SlicePredicate colPredicate, ConsistencyLevel cLevel) throws PelopsException {
         return getSuperColumnsFromRow(columnFamily, fromUTF8(rowKey), colPredicate, cLevel);
     }
 
@@ -623,7 +623,7 @@ public class Selector extends Operand {
      * @return                              A list of matching columns
      * @throws PelopsException if an error occurs
      */
-    public List<SuperColumn> getSuperColumnsFromRow(final String columnFamily, final Bytes rowKey, final boolean reversed, final ConsistencyLevel cLevel) throws PelopsException {
+    public List<SuperColumn> getSuperColumnsFromRow(String columnFamily, Bytes rowKey, boolean reversed, ConsistencyLevel cLevel) throws PelopsException {
         return getSuperColumnsFromRow(columnFamily, rowKey, columnsPredicateAll(reversed), cLevel);
     }
 
@@ -636,7 +636,7 @@ public class Selector extends Operand {
      * @return                              A list of matching columns
      * @throws PelopsException if an error occurs
      */
-    public List<SuperColumn> getSuperColumnsFromRow(final String columnFamily, final Bytes rowKey, final SlicePredicate colPredicate, final ConsistencyLevel cLevel) throws PelopsException {
+    public List<SuperColumn> getSuperColumnsFromRow(String columnFamily, final Bytes rowKey, final SlicePredicate colPredicate, final ConsistencyLevel cLevel) throws PelopsException {
         final ColumnParent cp = newColumnParent(columnFamily);
         IOperation<List<SuperColumn>> operation = new IOperation<List<SuperColumn>>() {
             @Override
@@ -704,7 +704,7 @@ public class Selector extends Operand {
      * @return                              A page of columns
      * @throws PelopsException if an error occurs
      */
-    public List<Column> getPageOfColumnsFromRow(final String columnFamily, final Bytes rowKey, final Bytes startBeyondName, final boolean reversed, final int count, final ConsistencyLevel cLevel) throws PelopsException {
+    public List<Column> getPageOfColumnsFromRow(String columnFamily, Bytes rowKey, Bytes startBeyondName, boolean reversed, int count, ConsistencyLevel cLevel) throws PelopsException {
         SlicePredicate predicate;
         if (Bytes.nullSafeGet(startBeyondName) == null) {
             predicate = Selector.newColumnsPredicateAll(reversed, count);
@@ -737,7 +737,7 @@ public class Selector extends Operand {
      * @return                              A page of column names
      * @throws PelopsException if an error occurs
      */
-    public List<Bytes> getPageOfColumnNamesFromRow(final String columnFamily, final Bytes rowKey, final Bytes startBeyondName, final boolean reversed, final int count, final ConsistencyLevel cLevel) throws PelopsException {
+    public List<Bytes> getPageOfColumnNamesFromRow(String columnFamily, Bytes rowKey, Bytes startBeyondName, boolean reversed, int count, ConsistencyLevel cLevel) throws PelopsException {
         List<Column> columns = getPageOfColumnsFromRow(columnFamily, rowKey, startBeyondName, reversed, count, cLevel);
         // transform to a list of column names
         List<Bytes> columnNames = new ArrayList<Bytes>(columns.size());
@@ -761,7 +761,7 @@ public class Selector extends Operand {
      * @return                              A page of super columns
      * @throws PelopsException if an error occurs
      */
-    public Iterator<Column> iterateColumnsFromRow(final String columnFamily, final Bytes rowKey, final Bytes startBeyondName, final boolean reversed, final int batchSize, final ConsistencyLevel cLevel) {
+    public Iterator<Column> iterateColumnsFromRow(String columnFamily, Bytes rowKey, Bytes startBeyondName, boolean reversed, int batchSize, ConsistencyLevel cLevel) {
         return new ColumnIterator(this, columnFamily, rowKey, startBeyondName, reversed, batchSize, cLevel);
     }
 
@@ -778,7 +778,7 @@ public class Selector extends Operand {
      * @return                              A page of super columns
      * @throws PelopsException if an error occurs
      */
-    public Iterator<Column> iterateColumnsFromRow(final String columnFamily, final String rowKey, final String startBeyondName, final boolean reversed, final int batchSize, final ConsistencyLevel cLevel) {
+    public Iterator<Column> iterateColumnsFromRow(String columnFamily, String rowKey, String startBeyondName, boolean reversed, int batchSize, ConsistencyLevel cLevel) {
         return iterateColumnsFromRow(columnFamily, Bytes.fromUTF8(rowKey), Bytes.fromUTF8(startBeyondName), reversed, batchSize, cLevel);
     }
 
@@ -793,7 +793,7 @@ public class Selector extends Operand {
      * @return                              A page of super columns
      * @throws PelopsException if an error occurs
      */
-    public List<SuperColumn> getPageOfSuperColumnsFromRow(final String columnFamily, String rowKey, Bytes startBeyondName, boolean reversed, int count, ConsistencyLevel cLevel) throws PelopsException {
+    public List<SuperColumn> getPageOfSuperColumnsFromRow(String columnFamily, String rowKey, Bytes startBeyondName, boolean reversed, int count, ConsistencyLevel cLevel) throws PelopsException {
     	return getPageOfSuperColumnsFromRow(columnFamily, fromUTF8(rowKey), startBeyondName, reversed, count, cLevel);
     }
 
@@ -808,7 +808,7 @@ public class Selector extends Operand {
      * @return                              A page of super columns
      * @throws PelopsException if an error occurs
      */
-    public List<SuperColumn> getPageOfSuperColumnsFromRow(final String columnFamily, String rowKey, String startBeyondName, boolean reversed, int count, ConsistencyLevel cLevel) throws PelopsException {
+    public List<SuperColumn> getPageOfSuperColumnsFromRow(String columnFamily, String rowKey, String startBeyondName, boolean reversed, int count, ConsistencyLevel cLevel) throws PelopsException {
     	return getPageOfSuperColumnsFromRow(columnFamily, fromUTF8(rowKey), fromUTF8(startBeyondName), reversed, count, cLevel);
     }
 
@@ -823,7 +823,7 @@ public class Selector extends Operand {
      * @return                              A page of super columns
      * @throws PelopsException if an error occurs
      */
-    public List<SuperColumn> getPageOfSuperColumnsFromRow(final String columnFamily, Bytes rowKey, String startBeyondName, boolean reversed, int count, ConsistencyLevel cLevel) throws PelopsException {
+    public List<SuperColumn> getPageOfSuperColumnsFromRow(String columnFamily, Bytes rowKey, String startBeyondName, boolean reversed, int count, ConsistencyLevel cLevel) throws PelopsException {
     	return getPageOfSuperColumnsFromRow(columnFamily, rowKey, fromUTF8(startBeyondName), reversed, count, cLevel);
     }
 
@@ -838,7 +838,7 @@ public class Selector extends Operand {
      * @return                              A page of super columns
      * @throws PelopsException if an error occurs
      */
-    public List<SuperColumn> getPageOfSuperColumnsFromRow(final String columnFamily, final Bytes rowKey, final Bytes startBeyondName, final boolean reversed, final int count, final ConsistencyLevel cLevel) throws PelopsException {
+    public List<SuperColumn> getPageOfSuperColumnsFromRow(String columnFamily, Bytes rowKey, Bytes startBeyondName, boolean reversed, int count, ConsistencyLevel cLevel) throws PelopsException {
         if (Bytes.nullSafeGet(startBeyondName) == null) {
             SlicePredicate predicate = Selector.newColumnsPredicateAll(reversed, count);
             return getSuperColumnsFromRow(columnFamily, rowKey, predicate, cLevel);
@@ -870,7 +870,7 @@ public class Selector extends Operand {
      * @return                              A page of super columns
      * @throws PelopsException if an error occurs
      */
-    public Iterator<SuperColumn> iterateSuperColumnsFromRow(final String columnFamily, final Bytes rowKey, final Bytes startBeyondName, final boolean reversed, final int batchSize, final ConsistencyLevel cLevel) {
+    public Iterator<SuperColumn> iterateSuperColumnsFromRow(String columnFamily, Bytes rowKey, Bytes startBeyondName, boolean reversed, int batchSize, ConsistencyLevel cLevel) {
         return new SuperColumnIterator(this, columnFamily, rowKey, startBeyondName, reversed, batchSize, cLevel);
     }
 
@@ -887,7 +887,7 @@ public class Selector extends Operand {
      * @return                              A page of super columns
      * @throws PelopsException if an error occurs
      */
-    public Iterator<SuperColumn> iterateSuperColumnsFromRow(final String columnFamily, String rowKey, String startBeyondName, final boolean reversed, final int batchSize, final ConsistencyLevel cLevel) {
+    public Iterator<SuperColumn> iterateSuperColumnsFromRow(String columnFamily, String rowKey, String startBeyondName, boolean reversed, int batchSize, ConsistencyLevel cLevel) {
         return iterateSuperColumnsFromRow(columnFamily, Bytes.fromUTF8(rowKey), Bytes.fromUTF8(startBeyondName), reversed, batchSize, cLevel);
     }
 
@@ -1081,7 +1081,7 @@ public class Selector extends Operand {
      * @return                               A map from row keys to the matching lists of super columns
      * @throws PelopsException if an error occurs
      */
-    public Map<Bytes, List<SuperColumn>> getSuperColumnsFromRows(final String columnFamily, final List<Bytes> rowKeys, final boolean reversed, final ConsistencyLevel cLevel) throws PelopsException {
+    public Map<Bytes, List<SuperColumn>> getSuperColumnsFromRows(String columnFamily, List<Bytes> rowKeys, boolean reversed, ConsistencyLevel cLevel) throws PelopsException {
         return getSuperColumnsFromRows(columnFamily, rowKeys, columnsPredicateAll(reversed), cLevel);
     }
 
@@ -1094,7 +1094,7 @@ public class Selector extends Operand {
      * @return                               A map from row keys to the matching lists of super columns
      * @throws PelopsException if an error occurs
      */
-    public Map<Bytes, List<SuperColumn>> getSuperColumnsFromRows(final String columnFamily, final List<Bytes> rowKeys, final SlicePredicate colPredicate, final ConsistencyLevel cLevel) throws PelopsException {
+    public Map<Bytes, List<SuperColumn>> getSuperColumnsFromRows(String columnFamily, final List<Bytes> rowKeys, final SlicePredicate colPredicate, final ConsistencyLevel cLevel) throws PelopsException {
         final ColumnParent cp = newColumnParent(columnFamily);
         final List<ByteBuffer> keys = Bytes.transformBytesToList(rowKeys);
         IOperation<Map<Bytes, List<SuperColumn>>> operation = new IOperation<Map<Bytes, List<SuperColumn>>>() {
@@ -1126,7 +1126,7 @@ public class Selector extends Operand {
      * @return                               A map from row keys to the matching lists of super columns
      * @throws PelopsException if an error occurs
      */
-    public Map<String, List<SuperColumn>> getSuperColumnsFromRowsUtf8Keys(final String columnFamily, final List<String> rowKeys, final boolean reversed, final ConsistencyLevel cLevel) throws PelopsException {
+    public Map<String, List<SuperColumn>> getSuperColumnsFromRowsUtf8Keys(String columnFamily, List<String> rowKeys, boolean reversed, ConsistencyLevel cLevel) throws PelopsException {
         return getSuperColumnsFromRowsUtf8Keys(columnFamily, rowKeys, columnsPredicateAll(reversed), cLevel);
     }
 
@@ -1139,7 +1139,7 @@ public class Selector extends Operand {
      * @return                               A map from row keys to the matching lists of super columns
      * @throws PelopsException if an error occurs
      */
-    public Map<String, List<SuperColumn>> getSuperColumnsFromRowsUtf8Keys(final String columnFamily, final List<String> rowKeys, final SlicePredicate colPredicate, final ConsistencyLevel cLevel) throws PelopsException {
+    public Map<String, List<SuperColumn>> getSuperColumnsFromRowsUtf8Keys(String columnFamily, List<String> rowKeys, final SlicePredicate colPredicate, final ConsistencyLevel cLevel) throws PelopsException {
         final ColumnParent cp = newColumnParent(columnFamily);
         final List<ByteBuffer> keys = Bytes.transformUTF8ToList(rowKeys);
         IOperation<Map<String, List<SuperColumn>>> operation = new IOperation<Map<String, List<SuperColumn>>>() {
@@ -1411,7 +1411,7 @@ public class Selector extends Operand {
      * @return                                A map from row keys to the matching lists of super columns
      * @throws PelopsException if an error occurs
      */
-    public Map<Bytes, List<SuperColumn>> getSuperColumnsFromRows(final String columnFamily, final KeyRange keyRange, final boolean reversed, final ConsistencyLevel cLevel) throws PelopsException {
+    public Map<Bytes, List<SuperColumn>> getSuperColumnsFromRows(String columnFamily, KeyRange keyRange, boolean reversed, ConsistencyLevel cLevel) throws PelopsException {
         return getSuperColumnsFromRows(columnFamily, keyRange, columnsPredicateAll(reversed), cLevel);
     }
 
@@ -1427,7 +1427,7 @@ public class Selector extends Operand {
      * @return                                A map from row keys to the matching lists of super columns
      * @throws PelopsException if an error occurs
      */
-    public Map<Bytes, List<SuperColumn>> getSuperColumnsFromRows(final String columnFamily, final KeyRange keyRange, final SlicePredicate colPredicate, final ConsistencyLevel cLevel) throws PelopsException {
+    public Map<Bytes, List<SuperColumn>> getSuperColumnsFromRows(String columnFamily, final KeyRange keyRange, final SlicePredicate colPredicate, final ConsistencyLevel cLevel) throws PelopsException {
         final ColumnParent cp = newColumnParent(columnFamily);
         IOperation<Map<Bytes, List<SuperColumn>>> operation = new IOperation<Map<Bytes, List<SuperColumn>>>() {
             @Override
@@ -1457,7 +1457,7 @@ public class Selector extends Operand {
      * @return                                A map from row keys to the matching lists of super columns
      * @throws PelopsException if an error occurs
      */
-    public Map<String, List<SuperColumn>> getSuperColumnsFromRowsUtf8Keys(final String columnFamily, final KeyRange keyRange, final boolean reversed, final ConsistencyLevel cLevel) throws PelopsException {
+    public Map<String, List<SuperColumn>> getSuperColumnsFromRowsUtf8Keys(String columnFamily, KeyRange keyRange, boolean reversed, ConsistencyLevel cLevel) throws PelopsException {
         return getSuperColumnsFromRowsUtf8Keys(columnFamily, keyRange, columnsPredicateAll(reversed), cLevel);
     }
 
@@ -1473,7 +1473,7 @@ public class Selector extends Operand {
      * @return                                A map from row keys to the matching lists of super columns
      * @throws PelopsException if an error occurs
      */
-    public Map<String, List<SuperColumn>> getSuperColumnsFromRowsUtf8Keys(final String columnFamily, final KeyRange keyRange, final SlicePredicate colPredicate, final ConsistencyLevel cLevel) throws PelopsException {
+    public Map<String, List<SuperColumn>> getSuperColumnsFromRowsUtf8Keys(String columnFamily, final KeyRange keyRange, final SlicePredicate colPredicate, final ConsistencyLevel cLevel) throws PelopsException {
         final ColumnParent cp = newColumnParent(columnFamily);
         IOperation<Map<String, List<SuperColumn>>> operation = new IOperation<Map<String, List<SuperColumn>>>() {
             @Override
@@ -1569,7 +1569,7 @@ public class Selector extends Operand {
      * @return                                A map from row keys to the matching lists of columns
      * @throws PelopsException if an error occurs
      */
-    public Map<Bytes, List<Column>> getIndexedColumns(final ColumnParent colParent, final IndexClause indexClause, final boolean reversed, final ConsistencyLevel cLevel) throws PelopsException {
+    public Map<Bytes, List<Column>> getIndexedColumns(ColumnParent colParent, IndexClause indexClause, boolean reversed, ConsistencyLevel cLevel) throws PelopsException {
         return getIndexedColumns(colParent, indexClause, columnsPredicateAll(reversed), cLevel);
     }
 

--- a/src/main/java/org/scale7/cassandra/pelops/Selector.java
+++ b/src/main/java/org/scale7/cassandra/pelops/Selector.java
@@ -1147,10 +1147,10 @@ public class Selector extends Operand {
             public Map<String, List<SuperColumn>> execute(IPooledConnection conn) throws Exception {
                 Map<ByteBuffer, List<ColumnOrSuperColumn>> apiResult = conn.getAPI().multiget_slice(keys, cp, colPredicate, cLevel);
                 Map<String, List<SuperColumn>> result = new LinkedHashMap<String, List<SuperColumn>>();
-                for (String rowKey : rowKeys) {
-                    List<ColumnOrSuperColumn> coscList = apiResult.get(fromUTF8(rowKey).getBytes());
+                for (int i = 0, rowKeysSize = rowKeys.size(); i < rowKeysSize; i++) {
+                    List<ColumnOrSuperColumn> coscList = apiResult.get(keys.get(i));
                     List<SuperColumn> columns = toSuperColumnList(coscList);
-                    result.put(rowKey, columns);
+                    result.put(rowKeys.get(i), columns);
                 }
                 return result;
             }
@@ -1183,10 +1183,10 @@ public class Selector extends Operand {
             public Map<String, List<Column>> execute(IPooledConnection conn) throws Exception {
                 Map<ByteBuffer, List<ColumnOrSuperColumn>> apiResult = conn.getAPI().multiget_slice(keys, colParent, colPredicate, cLevel);
                 Map<String, List<Column>> result = new LinkedHashMap<String, List<Column>>();
-                for (String rowKey : rowKeys) {
-                    List<ColumnOrSuperColumn> coscList = apiResult.get(fromUTF8(rowKey).getBytes());
+                for (int i = 0, rowKeysSize = rowKeys.size(); i < rowKeysSize; i++) {
+                    List<ColumnOrSuperColumn> coscList = apiResult.get(keys.get(i));
                     List<Column> columns = toColumnList(coscList);
-                    result.put(rowKey, columns);
+                    result.put(rowKeys.get(i), columns);
                 }
                 return result;
             }

--- a/src/main/java/org/scale7/cassandra/pelops/Selector.java
+++ b/src/main/java/org/scale7/cassandra/pelops/Selector.java
@@ -296,8 +296,7 @@ public class Selector extends Operand {
         IOperation<Column> operation = new IOperation<Column>() {
             @Override
             public Column execute(IThriftPool.IPooledConnection conn) throws Exception {
-                ColumnPath cp = new ColumnPath(columnFamily);
-                cp.setColumn(nullSafeGet(colName));
+                ColumnPath cp = newColumnPath(columnFamily, null, colName);
                 ColumnOrSuperColumn cosc = conn.getAPI().get(nullSafeGet(rowKey), cp, cLevel);
                 return cosc.column;
             }
@@ -347,8 +346,7 @@ public class Selector extends Operand {
         IOperation<SuperColumn> operation = new IOperation<SuperColumn>() {
             @Override
             public SuperColumn execute(IThriftPool.IPooledConnection conn) throws Exception {
-                ColumnPath cp = new ColumnPath(columnFamily);
-                cp.setSuper_column(nullSafeGet(superColName));
+                ColumnPath cp = newColumnPath(columnFamily, superColName, null);
                 ColumnOrSuperColumn cosc = conn.getAPI().get(nullSafeGet(rowKey), cp, cLevel);
                 return cosc.super_column;
             }
@@ -431,9 +429,7 @@ public class Selector extends Operand {
         IOperation<Column> operation = new IOperation<Column>() {
             @Override
             public Column execute(IThriftPool.IPooledConnection conn) throws Exception {
-                ColumnPath cp = new ColumnPath(columnFamily);
-                cp.setSuper_column(nullSafeGet(superColName));
-                cp.setColumn(nullSafeGet(subColName));
+                ColumnPath cp = newColumnPath(columnFamily, superColName, subColName);
                 ColumnOrSuperColumn cosc = conn.getAPI().get(nullSafeGet(rowKey), cp, cLevel);
                 return cosc.column;
             }
@@ -1984,6 +1980,13 @@ public class Selector extends Operand {
      */
     public Selector(IThriftPool thrift) {
         super(thrift);
+    }
+
+    private static ColumnPath newColumnPath(String columnFamily, Bytes superColName, Bytes colName) {
+        ColumnPath path = new ColumnPath(columnFamily);
+        path.setSuper_column(nullSafeGet(superColName));
+        path.setColumn(nullSafeGet(colName));
+        return path;
     }
 
     private static ColumnParent newColumnParent(String columnFamily, String superColName) {

--- a/src/main/java/org/scale7/cassandra/pelops/Selector.java
+++ b/src/main/java/org/scale7/cassandra/pelops/Selector.java
@@ -1096,10 +1096,11 @@ public class Selector extends Operand {
      */
     public Map<Bytes, List<SuperColumn>> getSuperColumnsFromRows(final String columnFamily, final List<Bytes> rowKeys, final SlicePredicate colPredicate, final ConsistencyLevel cLevel) throws PelopsException {
         final ColumnParent cp = newColumnParent(columnFamily);
+        final List<ByteBuffer> keys = Bytes.transformBytesToList(rowKeys);
         IOperation<Map<Bytes, List<SuperColumn>>> operation = new IOperation<Map<Bytes, List<SuperColumn>>>() {
             @Override
             public Map<Bytes, List<SuperColumn>> execute(IPooledConnection conn) throws Exception {
-                Map<ByteBuffer, List<ColumnOrSuperColumn>> apiResult = conn.getAPI().multiget_slice(Bytes.transformBytesToList(rowKeys), cp, colPredicate, cLevel);
+                Map<ByteBuffer, List<ColumnOrSuperColumn>> apiResult = conn.getAPI().multiget_slice(keys, cp, colPredicate, cLevel);
                 Map<Bytes, List<SuperColumn>> result = new LinkedHashMap<Bytes, List<SuperColumn>>();
                 for (Bytes rowKey : rowKeys) {
                     List<ColumnOrSuperColumn> coscList = apiResult.get(rowKey.getBytes());
@@ -1140,10 +1141,11 @@ public class Selector extends Operand {
      */
     public Map<String, List<SuperColumn>> getSuperColumnsFromRowsUtf8Keys(final String columnFamily, final List<String> rowKeys, final SlicePredicate colPredicate, final ConsistencyLevel cLevel) throws PelopsException {
         final ColumnParent cp = newColumnParent(columnFamily);
+        final List<ByteBuffer> keys = Bytes.transformUTF8ToList(rowKeys);
         IOperation<Map<String, List<SuperColumn>>> operation = new IOperation<Map<String, List<SuperColumn>>>() {
             @Override
             public Map<String, List<SuperColumn>> execute(IPooledConnection conn) throws Exception {
-                Map<ByteBuffer, List<ColumnOrSuperColumn>> apiResult = conn.getAPI().multiget_slice(Bytes.transformUTF8ToList(rowKeys), cp, colPredicate, cLevel);
+                Map<ByteBuffer, List<ColumnOrSuperColumn>> apiResult = conn.getAPI().multiget_slice(keys, cp, colPredicate, cLevel);
                 Map<String, List<SuperColumn>> result = new LinkedHashMap<String, List<SuperColumn>>();
                 for (Map.Entry<ByteBuffer, List<ColumnOrSuperColumn>> rowEntry : apiResult.entrySet()) {
                     List<SuperColumn> columns = toSuperColumnList(rowEntry.getValue());
@@ -1156,10 +1158,11 @@ public class Selector extends Operand {
     }
 
     private Map<Bytes, List<Column>> getColumnsFromRows(final ColumnParent colParent, final List<Bytes> rowKeys, final SlicePredicate colPredicate, final ConsistencyLevel cLevel) throws PelopsException {
+        final List<ByteBuffer> keys = Bytes.transformBytesToList(rowKeys);
         IOperation<Map<Bytes, List<Column>>> operation = new IOperation<Map<Bytes, List<Column>>>() {
             @Override
             public Map<Bytes, List<Column>> execute(IThriftPool.IPooledConnection conn) throws Exception {
-                Map<ByteBuffer, List<ColumnOrSuperColumn>> apiResult = conn.getAPI().multiget_slice(Bytes.transformBytesToList(rowKeys), colParent, colPredicate, cLevel);
+                Map<ByteBuffer, List<ColumnOrSuperColumn>> apiResult = conn.getAPI().multiget_slice(keys, colParent, colPredicate, cLevel);
                 Map<Bytes, List<Column>> result = new LinkedHashMap<Bytes, List<Column>>();
                 for (Bytes rowKey : rowKeys) {
                     List<ColumnOrSuperColumn> coscList = apiResult.get(rowKey.getBytes());
@@ -1173,10 +1176,11 @@ public class Selector extends Operand {
     }
 
     private Map<String, List<Column>> getColumnsFromRowsUtf8Keys(final ColumnParent colParent, final List<String> rowKeys, final SlicePredicate colPredicate, final ConsistencyLevel cLevel) throws PelopsException {
+        final List<ByteBuffer> keys = Bytes.transformUTF8ToList(rowKeys);
         IOperation<Map<String, List<Column>>> operation = new IOperation<Map<String, List<Column>>>() {
             @Override
             public Map<String, List<Column>> execute(IPooledConnection conn) throws Exception {
-                Map<ByteBuffer, List<ColumnOrSuperColumn>> apiResult = conn.getAPI().multiget_slice(Bytes.transformUTF8ToList(rowKeys), colParent, colPredicate, cLevel);
+                Map<ByteBuffer, List<ColumnOrSuperColumn>> apiResult = conn.getAPI().multiget_slice(keys, colParent, colPredicate, cLevel);
                 Map<String, List<Column>> result = new LinkedHashMap<String, List<Column>>();
                 for (String rowKey : rowKeys) {
                     List<ColumnOrSuperColumn> coscList = apiResult.get(fromUTF8(rowKey).getBytes());

--- a/src/main/java/org/scale7/cassandra/pelops/Selector.java
+++ b/src/main/java/org/scale7/cassandra/pelops/Selector.java
@@ -1146,10 +1146,9 @@ public class Selector extends Operand {
             public Map<String, List<SuperColumn>> execute(IPooledConnection conn) throws Exception {
                 Map<ByteBuffer, List<ColumnOrSuperColumn>> apiResult = conn.getAPI().multiget_slice(Bytes.transformUTF8ToList(rowKeys), newColumnParent(columnFamily), colPredicate, cLevel);
                 Map<String, List<SuperColumn>> result = new LinkedHashMap<String, List<SuperColumn>>();
-                for (ByteBuffer rowKey : apiResult.keySet()) {
-                    List<ColumnOrSuperColumn> coscList = apiResult.get(rowKey);
-                    List<SuperColumn> columns = toSuperColumnList(coscList);
-                    result.put(toUTF8(rowKey), columns);
+                for (Map.Entry<ByteBuffer, List<ColumnOrSuperColumn>> rowEntry : apiResult.entrySet()) {
+                    List<SuperColumn> columns = toSuperColumnList(rowEntry.getValue());
+                    result.put(toUTF8(rowEntry.getKey()), columns);
                 }
                 return result;
             }

--- a/src/test/java/org/scale7/cassandra/pelops/BytesUnitTest.java
+++ b/src/test/java/org/scale7/cassandra/pelops/BytesUnitTest.java
@@ -86,11 +86,11 @@ public class BytesUnitTest {
      */
     @Test
     public void testByteBuffer() {
-        ByteBuffer buffer = ByteBuffer.allocate(Bytes.SIZEOF_DOUBLE + Bytes.SIZEOF_BYTE + Bytes.SIZEOF_LONG);
+        ByteBuffer buffer = ByteBuffer.allocate(Bytes.BufferHelper.SIZEOF_DOUBLE + Bytes.BufferHelper.SIZEOF_BYTE + Bytes.BufferHelper.SIZEOF_LONG);
         buffer.putDouble(Double.MAX_VALUE).put((byte) 9).putLong(Long.MAX_VALUE);
 
         Bytes from = Bytes.fromByteBuffer(
-                ByteBuffer.wrap(buffer.array(), Bytes.SIZEOF_DOUBLE + 1, Bytes.SIZEOF_BYTE)
+                ByteBuffer.wrap(buffer.array(), Bytes.BufferHelper.SIZEOF_DOUBLE + 1, Bytes.BufferHelper.SIZEOF_BYTE)
         );
         byte to = from.toByte();
 
@@ -425,11 +425,11 @@ public class BytesUnitTest {
     public void testUTF8Buffer() {
         String string = "This is a test";
 
-        ByteBuffer buffer = ByteBuffer.allocate(Bytes.SIZEOF_DOUBLE + string.length() + Bytes.SIZEOF_LONG);
-        buffer.putDouble(Double.MAX_VALUE).put(string.getBytes(Bytes.UTF8)).putLong(Long.MAX_VALUE);
+        ByteBuffer buffer = ByteBuffer.allocate(Bytes.BufferHelper.SIZEOF_DOUBLE + string.length() + Bytes.BufferHelper.SIZEOF_LONG);
+        buffer.putDouble(Double.MAX_VALUE).put(string.getBytes(Bytes.BufferHelper.UTF8)).putLong(Long.MAX_VALUE);
 
         Bytes from = Bytes.fromByteBuffer(
-                ByteBuffer.wrap(buffer.array(), Bytes.SIZEOF_DOUBLE, string.length())
+                ByteBuffer.wrap(buffer.array(), Bytes.BufferHelper.SIZEOF_DOUBLE, string.length())
         );
         String to = from.toUTF8();
 
@@ -443,12 +443,12 @@ public class BytesUnitTest {
 
     @Test
     public void testLength() {
-        ByteBuffer buffer = ByteBuffer.allocate(Bytes.SIZEOF_DOUBLE + Bytes.SIZEOF_INT + Bytes.SIZEOF_LONG);
+        ByteBuffer buffer = ByteBuffer.allocate(Bytes.BufferHelper.SIZEOF_DOUBLE + Bytes.BufferHelper.SIZEOF_INT + Bytes.BufferHelper.SIZEOF_LONG);
         buffer.putDouble(Double.MAX_VALUE).putInt(Integer.MIN_VALUE).putLong(Long.MAX_VALUE);
 
-        Bytes bytes = Bytes.fromByteBuffer(ByteBuffer.wrap(buffer.array(), Bytes.SIZEOF_DOUBLE, Bytes.SIZEOF_INT));
+        Bytes bytes = Bytes.fromByteBuffer(ByteBuffer.wrap(buffer.array(), Bytes.BufferHelper.SIZEOF_DOUBLE, Bytes.BufferHelper.SIZEOF_INT));
 
-        assertEquals("The length method didn't return the correct value", Bytes.SIZEOF_INT, bytes.length());
+        assertEquals("The length method didn't return the correct value", Bytes.BufferHelper.SIZEOF_INT, bytes.length());
     }
 
     @Test
@@ -473,11 +473,11 @@ public class BytesUnitTest {
         assertEquals("Duplicate not equal", bytes, bytes.duplicate());
 
         String string = "some string";
-        ByteBuffer buffer = ByteBuffer.allocate(Bytes.SIZEOF_DOUBLE + string.length() + Bytes.SIZEOF_LONG);
-        buffer.putDouble(Double.MAX_VALUE).put(string.getBytes(Bytes.UTF8)).putLong(Long.MAX_VALUE);
+        ByteBuffer buffer = ByteBuffer.allocate(Bytes.BufferHelper.SIZEOF_DOUBLE + string.length() + Bytes.BufferHelper.SIZEOF_LONG);
+        buffer.putDouble(Double.MAX_VALUE).put(string.getBytes(Bytes.BufferHelper.UTF8)).putLong(Long.MAX_VALUE);
 
         bytes = Bytes.fromByteBuffer(
-                ByteBuffer.wrap(buffer.array(), Bytes.SIZEOF_DOUBLE, string.length())
+                ByteBuffer.wrap(buffer.array(), Bytes.BufferHelper.SIZEOF_DOUBLE, string.length())
         );
         assertEquals("Duplicate not equal", bytes, bytes.duplicate());
     }
@@ -492,7 +492,7 @@ public class BytesUnitTest {
 
         final byte[] target = new byte[3];
         byteBuffer.get(target, 0, 3);
-        String utf8PartActual = new String(target, Bytes.UTF8);
+        String utf8PartActual = new String(target, Bytes.BufferHelper.UTF8);
 
         int intPartActual = byteBuffer.getInt();
 

--- a/src/test/java/org/scale7/cassandra/pelops/pool/CommonsBackedPoolIntegrationTest.java
+++ b/src/test/java/org/scale7/cassandra/pelops/pool/CommonsBackedPoolIntegrationTest.java
@@ -293,7 +293,7 @@ public class CommonsBackedPoolIntegrationTest extends AbstractIntegrationTest {
     public void testInitWithDownedNode() throws Exception {
         final int timeout = 2000;
         final int allowedDeviation = 10; // allowed timeout deviation in percentage
-        Cluster cluster = new Cluster(new String[] {RPC_LISTEN_ADDRESS, "127.0.0.2"}, new IConnection.Config(RPC_PORT, true, timeout), false);
+        Cluster cluster = new Cluster(new String[] {RPC_LISTEN_ADDRESS, "192.0.2.0"}, new IConnection.Config(RPC_PORT, true, timeout), false);
 
         CommonsBackedPool.Policy config = new CommonsBackedPool.Policy();
         config.setTimeBetweenScheduledMaintenanceTaskRunsMillis(-1); // disable the background thread


### PR DESCRIPTION
1) deprecated redundant timeUuid methods for future removal: In continuance with the reverting of the former method removal - comes the compromise between the two, to finally bring balance to the force!
2) avoided unnecessary ByteBuffer duplication for internally allocated instances
3) replaced the problematic loopback address (127.0.0.2) in testInitWithDownedNode with a TEST-NET address (192.0.2.0)
4) encapsulated ByteBuffer allocation and avoided unnecessary Bytes creations in CompositeBuilder
5) completed HashMap->LinkedHashMap replacement missing in commit 48e2e13afcef47c498f2 and improved map iteration
6) reduced repeated object creations and String->ByteBuffer conversions inside IOperation anonymous implementations
7) fixed an inconsistency between methods iterating either over a given list of rowKeys, or over the API call result
