### PR TITLE
Improve wrapping of exceptions from Cassandra Thrift

### DIFF
--- a/src/main/java/org/scale7/cassandra/pelops/exceptions/AuthenticationException.java
+++ b/src/main/java/org/scale7/cassandra/pelops/exceptions/AuthenticationException.java
@@ -25,7 +25,7 @@
 package org.scale7.cassandra.pelops.exceptions;
 
 public class AuthenticationException extends PelopsException {
-    public AuthenticationException(Exception e) {
-        super(e.getMessage(), e);
+    public AuthenticationException(org.apache.cassandra.thrift.AuthenticationException e) {
+        super(e.getWhy(), e);
     }
 }

--- a/src/main/java/org/scale7/cassandra/pelops/exceptions/AuthorizationException.java
+++ b/src/main/java/org/scale7/cassandra/pelops/exceptions/AuthorizationException.java
@@ -25,7 +25,7 @@
 package org.scale7.cassandra.pelops.exceptions;
 
 public class AuthorizationException extends PelopsException {
-    public AuthorizationException(Exception e) {
-        super(e.getMessage(), e);
+    public AuthorizationException(org.apache.cassandra.thrift.AuthorizationException e) {
+        super(e.getWhy(), e);
     }
 }

--- a/src/main/java/org/scale7/cassandra/pelops/exceptions/IExceptionTranslator.java
+++ b/src/main/java/org/scale7/cassandra/pelops/exceptions/IExceptionTranslator.java
@@ -44,13 +44,13 @@ public interface IExceptionTranslator {
             if (e instanceof org.apache.cassandra.thrift.NotFoundException)
                 return new NotFoundException(e);
             else if (e instanceof org.apache.cassandra.thrift.InvalidRequestException)
-                return new InvalidRequestException(e);
+                return new InvalidRequestException((org.apache.cassandra.thrift.InvalidRequestException) e);
             else if (e instanceof org.apache.thrift.TApplicationException)
                 return new ApplicationException(e);
             else if (e instanceof org.apache.cassandra.thrift.AuthenticationException)
-                return new AuthenticationException(e);
+                return new AuthenticationException((org.apache.cassandra.thrift.AuthenticationException) e);
             else if (e instanceof org.apache.cassandra.thrift.AuthorizationException)
-                return new AuthorizationException(e);
+                return new AuthorizationException((org.apache.cassandra.thrift.AuthorizationException) e);
             else if (e instanceof org.apache.cassandra.thrift.TimedOutException)
                 return new TimedOutException(e);
             else if (e instanceof org.apache.thrift.transport.TTransportException)

--- a/src/main/java/org/scale7/cassandra/pelops/exceptions/InvalidRequestException.java
+++ b/src/main/java/org/scale7/cassandra/pelops/exceptions/InvalidRequestException.java
@@ -25,8 +25,8 @@
 package org.scale7.cassandra.pelops.exceptions;
 
 public class InvalidRequestException extends PelopsException {
-    public InvalidRequestException(Exception e) {
-        super(e.getMessage(), e);
+    public InvalidRequestException(org.apache.cassandra.thrift.InvalidRequestException e) {
+        super(e.getWhy(), e);
     }
 
     /**


### PR DESCRIPTION
Changed ExceptionTranslator and constructors of exception wrappers to use getWhy() instead of getMessage() for several Thrift Exceptions.
