### PR TITLE
Improve logging info and swith API method to public 

### DIFF
--- a/src/main/java/org/scale7/cassandra/pelops/Connection.java
+++ b/src/main/java/org/scale7/cassandra/pelops/Connection.java
@@ -99,6 +99,7 @@ public class Connection implements IConnection {
  			try {
 				getAPI().login(node.getConfig().getConnectionAuthenticator().getAuthenticationRequest());
 			} catch (Exception e) {
+				logger.warn("Failed to login on client for node {}.  Cause is {}", node.getAddress(),  e);
 				throw new IExceptionTranslator.ExceptionTranslator().translate(e);
 			} 
         }
@@ -109,7 +110,8 @@ public class Connection implements IConnection {
             try {
                 client.set_keyspace(keyspace);
             } catch (Exception e) {
-                logger.warn("Failed to set keyspace on client.  See cause for details...", e);
+                logger.warn("Failed to set keyspace on client for node {}.  Cause is {}", node.getAddress(),  e);
+                throw new IExceptionTranslator.ExceptionTranslator().translate(e);
             }
         }
     }

--- a/src/main/java/org/scale7/cassandra/pelops/Operand.java
+++ b/src/main/java/org/scale7/cassandra/pelops/Operand.java
@@ -90,8 +90,8 @@ public class Operand {
                     e instanceof TTransportException ||
                     e instanceof UnavailableException) {
 
-                    logger.warn("Operation failed as result of network exception. Connection is being marked as corrupt " +
-                            "(and will probably be be destroyed).  See cause for details...", e);
+                    logger.warn("Operation failed as result of network exception. Connection to node {} is being marked as corrupt " +
+                            "(and will probably be be destroyed). Cause of failure is {}", conn.getNode().getAddress(), e);
 
                     // This connection is "broken" by network timeout or other problem.
                     conn.corrupted();

--- a/src/main/java/org/scale7/cassandra/pelops/Selector.java
+++ b/src/main/java/org/scale7/cassandra/pelops/Selector.java
@@ -1760,7 +1760,7 @@ public class Selector extends Operand {
         return getSuperColumnsFromRows(columnFamily, keyRange, columnsPredicateAll(reversed), cLevel);
     }
 
-    private List<KeySlice> getKeySlices(final ColumnParent columnParent, final KeyRange keyRange, final SlicePredicate colPredicate, final ConsistencyLevel cLevel) throws PelopsException {
+    public List<KeySlice> getKeySlices(final ColumnParent columnParent, final KeyRange keyRange, final SlicePredicate colPredicate, final ConsistencyLevel cLevel) throws PelopsException {
         return tryOperation(new IOperation<List<KeySlice>>() {
             @Override
             public List<KeySlice> execute(IPooledConnection conn) throws Exception {


### PR DESCRIPTION
1)
Sometimes it is critical (because of performance) to use low level API and work with Thrift entities without transformation (each transformation is allocation of array). 

So there is  getKeySlices(final ColumnParent columnParent, final KeyRange keyRange, final SlicePredicate colPredicate, final ConsistencyLevel cLevel) method that is private, need to make it public.

2)
There is need to have in logs information about which node fails with timeout. Also stack trace while warning and retrying is confusing and doesn't provide any useful information.
